### PR TITLE
Fix for directory-change before removing afl-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ patch < RemoveInstrumentationCheck.diff
 # Install afl-fuzz
 make install
 cd ..
-rm -rf ../afl-2.52b/
+rm -rf afl-2.52b/
 
 # Install SharpFuzz.CommandLine global .NET tool
 dotnet tool install --global SharpFuzz.CommandLine

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ patch < RemoveInstrumentationCheck.diff
 
 # Install afl-fuzz
 make install
+cd ..
 rm -rf ../afl-2.52b/
 
 # Install SharpFuzz.CommandLine global .NET tool

--- a/build/Install.sh
+++ b/build/Install.sh
@@ -18,7 +18,7 @@ patch < RemoveInstrumentationCheck.diff
 # Install afl-fuzz
 make install
 cd ..
-rm -rf ../afl-2.52b/
+rm -rf afl-2.52b/
 
 # Install SharpFuzz.CommandLine global .NET tool
 dotnet tool install --global SharpFuzz.CommandLine

--- a/build/Install.sh
+++ b/build/Install.sh
@@ -17,6 +17,7 @@ patch < RemoveInstrumentationCheck.diff
 
 # Install afl-fuzz
 make install
+cd ..
 rm -rf ../afl-2.52b/
 
 # Install SharpFuzz.CommandLine global .NET tool


### PR DESCRIPTION
ReadMe.md got fixed in https://github.com/Metalnem/sharpfuzz/pull/1, but this change was lost with db9ba4a42ad3c3b070bff723648f7b42d595d386
install.sh didn't have this change / fix.

This PR brings the fix back, and applies it also to install.sh