### PR TITLE
Support `libfuzzer-dotnet` on Windows 

### DIFF
--- a/src/SharpFuzz/Fuzzer.LibFuzzer.cs
+++ b/src/SharpFuzz/Fuzzer.LibFuzzer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
 
 namespace SharpFuzz
 {
@@ -32,57 +34,59 @@ namespace SharpFuzz
 			public static unsafe void Run(ReadOnlySpanAction action)
 			{
 				ThrowIfNull(action, nameof(action));
-				var s = Environment.GetEnvironmentVariable("__LIBFUZZER_SHM_ID");
 
-				if (s is null || !Int32.TryParse(s, out var shmid))
+				try
 				{
-					RunWithoutLibFuzzer(action);
-					return;
-				}
-
-				using (var shmaddr = Native.shmat(shmid, IntPtr.Zero, 0))
-				using (var r = new BinaryReader(new AnonymousPipeClientStream(PipeDirection.In, "198")))
-				using (var w = new BinaryWriter(new AnonymousPipeClientStream(PipeDirection.Out, "199")))
-				{
-					var sharedMem = (byte*)shmaddr.DangerousGetHandle();
-					var trace = new TraceWrapper(sharedMem);
-
-					w.Write(0);
-
-					try
+					using (var ipc = new FuzzerIpc())
 					{
-						var status = Fault.None;
+						var sharedMem = ipc.InputPointer();
+						var trace = new TraceWrapper(sharedMem);
 
-						// The program instrumented with libFuzzer will exit
-						// after the first error, so we should do the same.
-						while (status != Fault.Crash)
+						ipc.SetStatus(0);
+
+						try
 						{
-							trace.ResetPrevLocation();
+							var status = Fault.None;
 
-							var size = r.ReadInt32();
-							var data = new ReadOnlySpan<byte>(sharedMem + MapSize, size);
-
-							try
+							// The program instrumented with libFuzzer will exit
+							// after the first error, so we should do the same.
+							while (status != Fault.Crash)
 							{
-								action(data);
-							}
-							catch (Exception ex)
-							{
-								Console.Error.WriteLine(ex);
-								status = Fault.Crash;
-							}
+								trace.ResetPrevLocation();
 
-							w.Write(status);
+								var size = ipc.InputSize();
+								var data = new ReadOnlySpan<byte>(sharedMem + MapSize, size);
+
+								try
+								{
+									action(data);
+								}
+								catch (Exception ex)
+								{
+									Console.Error.WriteLine(ex);
+									status = Fault.Crash;
+								}
+
+								ipc.SetStatus(status);
+							}
+						}
+						catch
+						{
+							// Error communicating with the parent process, most likely
+							// because it was terminated after the timeout expired, or
+							// it was killed by the user. In any case, the exception
+							// details don't matter here, so we can just exit silently.
+							return;
 						}
 					}
-					catch
-					{
-						// Error communicating with the parent process, most likely
-						// because it was terminated after the timeout expired, or
-						// it was killed by the user. In any case, the exception
-						// details don't matter here, so we can just exit silently.
-						return;
-					}
+				}
+				catch (FuzzerIpcEnvironmentException)
+				{
+					// Error establishing IPC with the parent process due to missing or
+					// definitely-invalid environment variables. This may be intentional.
+					// Instead of persistent fuzzing, fall back on testing a single input.
+					RunWithoutLibFuzzer(action);
+					return;
 				}
 			}
 
@@ -101,6 +105,162 @@ namespace SharpFuzz
 					action(File.ReadAllBytes(args[1]));
 				}
 			}
+		}
+	}
+
+	/// <summary>
+	///	  Cross-platform wrapper around an implementation of interprocess communication
+	///	  between SharpFuzz and a `libfuzzer-dotnet` process.
+	/// </summary>
+	class FuzzerIpc: IDisposable {
+		IFuzzerIpcImpl impl;
+
+		/// <summary>
+		///	  Attempt to initialize IPC for the current platform, using identifier data
+		///	  passed via environment variables.
+		/// </summary>
+		public FuzzerIpc()
+		{
+			var shmId = Environment.GetEnvironmentVariable("__LIBFUZZER_SHM_ID");
+			var statusPipeId = Environment.GetEnvironmentVariable("__LIBFUZZER_STATUS_PIPE_ID");
+			var controlPipeId = Environment.GetEnvironmentVariable("__LIBFUZZER_CONTROL_PIPE_ID");
+
+			if (shmId == null || statusPipeId == null || controlPipeId == null)
+			{
+				throw new FuzzerIpcEnvironmentException();
+			}
+
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				impl = new WindowsFuzzerIpc(shmId, statusPipeId, controlPipeId);
+			}
+			else
+			{
+				if (!Int32.TryParse(shmId, out var posixShmId))
+				{
+					// The shared memory ID cannot be parsed as a 32-bit integer, which means it cannot
+					// have been the return value of `shmget(2)`, and cannot be passed to `shmat(2)`.
+					throw new FuzzerIpcEnvironmentException();
+				}
+
+				impl = new PosixFuzzerIpc(posixShmId, statusPipeId, controlPipeId);
+			}
+		}
+
+		public FuzzerIpc(IFuzzerIpcImpl impl)
+		{
+			this.impl = impl;
+		}
+
+		public unsafe byte* InputPointer()
+		{
+			return impl.Pointer();
+		}
+
+		public int InputSize()
+		{
+			return impl.Control.ReadInt32();
+		}
+
+		public void SetStatus(int status)
+		{
+			impl.Status.Write(status);
+		}
+
+		public void Dispose()
+		{
+			impl.Dispose();
+		}
+	}
+
+	/// <summary>
+	///	  Platform-specific implementation of interprocess communication between SharpFuzz
+	///	  and a `libfuzzer-dotnet` process.
+	/// </summary>
+	interface IFuzzerIpcImpl: IDisposable
+	{
+		public unsafe byte* Pointer();
+
+		public BinaryReader Control { get; }
+
+		public BinaryWriter Status { get; }
+	}
+
+	/// <summary>
+	///	  An error occurred when processing environment variables to initialize fuzzer IPC.
+	///	  For example, a required environment variable may not be set, or had a value that
+	///	  is definitely invalid.
+	///
+	///	  This exception does not imply an error when invoking platform APIs for setting up
+	///	  pipes or shared memory.
+	/// </summary>
+	class FuzzerIpcEnvironmentException: Exception
+	{
+	}
+
+	/// <summary>
+	///	  IPC implementation for `libfuzzer-dotnet` on POSIX OS platforms.
+	/// </summary>
+	class PosixFuzzerIpc: IFuzzerIpcImpl
+	{
+		public BinaryReader Control { get; }
+		public BinaryWriter Status { get; }
+
+		private SharedMemoryHandle shmHandle;
+
+		public PosixFuzzerIpc(int shmId, string statusPipeId, string controlPipeId)
+		{
+			Control = new BinaryReader(new AnonymousPipeClientStream(PipeDirection.In, controlPipeId));
+			Status = new BinaryWriter(new AnonymousPipeClientStream(PipeDirection.Out, statusPipeId));
+
+			shmHandle = Native.shmat(shmId, IntPtr.Zero, 0);
+		}
+
+		public unsafe byte* Pointer()
+		{
+			return (byte *) shmHandle.DangerousGetHandle();
+		}
+
+		public void Dispose()
+		{
+			Control.Dispose();
+			Status.Dispose();
+			shmHandle.Dispose();
+		}
+	}
+
+	/// <summary>
+	///	  IPC implementation for `libfuzzer-dotnet` on Windows.
+	/// </summary>
+	class WindowsFuzzerIpc: IFuzzerIpcImpl
+	{
+		public BinaryReader Control { get; }
+		public BinaryWriter Status { get; }
+
+		private MemoryMappedFile mmFile;
+		private MemoryMappedViewAccessor mmView;
+
+		public WindowsFuzzerIpc(string shmId, string statusPipeId, string controlPipeId)
+		{
+			mmFile = MemoryMappedFile.OpenExisting(shmId, MemoryMappedFileRights.FullControl);
+			mmView = mmFile.CreateViewAccessor();
+			Control = new BinaryReader(new AnonymousPipeClientStream(PipeDirection.In, controlPipeId));
+			Status = new BinaryWriter(new AnonymousPipeClientStream(PipeDirection.Out, statusPipeId));
+		}
+
+		public unsafe byte* Pointer()
+		{
+			byte* ptr = null;
+			mmView.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+			return ptr;
+		}
+
+		public void Dispose()
+		{
+			Control.Dispose();
+			Status.Dispose();
+			mmView.Dispose();
+			mmFile.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
### Summary

- Add support for a Windows port of `libfuzzer-dotnet` by providing multiple IPC implementations, with runtime auto-selection of the platform-appropriate impl.
- Remove some cross-file hardcoding and require that all `libfuzzer-dotnet` implementations set 3 environment variables: `__LIBFUZZER_SHM_ID`, `__LIBFUZZER_STATUS_PIPE_ID`, and `__LIBFUZZER_CONTROL_PIPE_ID`. The new, latter 2 vars are needed for the Windows port, so this unifies both platform impls.

### Notes

This is NOT compatible with the 1.0.0 version of [metalnem/libfuzzer-dotnet](https://github.com/Metalnem/libfuzzer-dotnet). The required (breaking) changes have been submitted to that repo (Metalnem/libfuzzer-dotnet#1.).

Coverage feedback via `__libfuzzer_extra_counters` only appears to work _on Windows_ starting with LLVM 14. However, fuzzing generally works with earlier versions.

### Testing

Tested both fuzzing and crash repro with local harnesses on Ubuntu 18.04 and Windows 10, using .NET 6.0 and Clang 10 (Linux only), 12, 13, and 14 (Windows).