### PR TITLE
Permit .NET 7.0 in SharpFuzz.CommandLine

### DIFF
--- a/src/SharpFuzz.CommandLine/SharpFuzz.CommandLine.csproj
+++ b/src/SharpFuzz.CommandLine/SharpFuzz.CommandLine.csproj
@@ -3,14 +3,14 @@
   <Import Project="..\..\build\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>sharpfuzz</ToolCommandName>
     <PackageId>SharpFuzz.CommandLine</PackageId>
     <Title>SharpFuzz.CommandLine</Title>
-    <PackageVersion>2.0.0</PackageVersion>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <PackageVersion>2.0.1</PackageVersion>
+    <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <Description>Command line tool for SharpFuzz instrumentation</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
Now that it is released. However, it’s possible the appveyor image doesn’t have support yet…