### PR TITLE
Use full path of fuzzing targets

### DIFF
--- a/scripts/fuzz-libfuzzer.ps1
+++ b/scripts/fuzz-libfuzzer.ps1
@@ -42,7 +42,7 @@ if (($fuzzingTargets | Measure-Object).Count -eq 0) {
 
 foreach ($fuzzingTarget in $fuzzingTargets) {
     Write-Output "Instrumenting $fuzzingTarget"
-    & $command $fuzzingTarget
+    & $command $fuzzingTarget.FullName
     
     if ($LastExitCode -ne 0) {
         Write-Error "An error occurred while instrumenting $fuzzingTarget"


### PR DESCRIPTION
Using PowerShell 5.1 `$command` reported 
```
Specified file does not exist.
```

as each `$fuzzingTarget` only uses the filename and not the full pat.