### PR TITLE
Update to AFL++

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 [license-shield]: https://img.shields.io/badge/license-MIT-blue.svg?style=flat
 [license-link]: https://github.com/metalnem/sharpfuzz/blob/master/LICENSE
 
-SharpFuzz is a tool that brings the power of [afl-fuzz]
+SharpFuzz is a tool that brings the power of [AFL++]
 to .NET platform. If you want to learn more about fuzzing,
 my motivation for writing SharpFuzz, the types of bugs
 it can find, or the technical details about how the
 integration with afl-fuzz works, read my blog post
 [SharpFuzz: Bringing the power of afl-fuzz to .NET platform](https://mijailovic.net/2019/01/03/sharpfuzz/).
 
-[afl-fuzz]: http://lcamtuf.coredump.cx/afl/
+[AFL++]: https://github.com/AFLplusplus/AFLplusplus
 
 ## Table of contents
 
@@ -138,14 +138,14 @@ request for the README file, or file an issue.
 
 ## Requirements
 
-AFL works on Linux and macOS. If you are using Windows, you can use any Linux distribution
+AFL++ works on Linux and macOS. If you are using Windows, you can use any Linux distribution
 that works under the [Windows Subsystem for Linux]. For native Windows support, you can use
 [libFuzzer](https://github.com/Metalnem/sharpfuzz/blob/master/docs/libFuzzer.md)
 instead of AFL.
 
 You will need GNU make and a working compiler
-(gcc or clang) in order to compile afl-fuzz.
-You will also need to have the [.NET Core 2.1]
+(gcc or clang) in order to compile afl-fuzz ([Installing AFL++](https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/INSTALL.md)).
+You will also need to have [.NET Core 2.1]
 or greater installed on your machine in order
 to instrument .NET assemblies with SharpFuzz.
 
@@ -159,23 +159,23 @@ recommended to install [PowerShell].
 ## Installation
 
 You can install afl-fuzz and [SharpFuzz.CommandLine]
-global .NET tool by running the following [script]:
+global .NET tool by running the following PowerShell [script]:
 
 ```shell
 #/bin/sh
 set -eux
 
 # Download and extract the latest afl-fuzz source package
-wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz
-tar -xvf afl-latest.tgz
+wget https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v4.30c.tar.gz
+tar -xvzf v4.30c.tar.gz
 
-rm afl-latest.tgz
-cd afl-2.52b/
+rm v4.30c.tar.gz
+cd AFLplusplus-4.30c/
 
 # Install afl-fuzz
 sudo make install
 cd ..
-rm -rf afl-2.52b/
+rm -rf AFLplusplus-4.30c/
 
 # Install SharpFuzz.CommandLine global .NET tool
 dotnet tool install --global SharpFuzz.CommandLine
@@ -188,15 +188,15 @@ dotnet tool install --global SharpFuzz.CommandLine
 
 This tutorial assumes that you are somewhat familiar
 with afl-fuzz. If you don't know anything about it, you
-should first read the [AFL quick start guide] and the
+should first read the [afl-fuzz approach] and the
 [afl-fuzz README]. If you have enough time, I would
-also recommend reading [Understanding the status screen]
-and [Technical whitepaper for afl-fuzz].
+also recommend reading [Fuzzing in depth]
+and [Technical whitepaper for AFL++].
 
-[AFL quick start guide]: http://lcamtuf.coredump.cx/afl/QuickStartGuide.txt
-[afl-fuzz README]: http://lcamtuf.coredump.cx/afl/README.txt
-[Understanding the status screen]: http://lcamtuf.coredump.cx/afl/status_screen.txt
-[Technical whitepaper for afl-fuzz]: http://lcamtuf.coredump.cx/afl/technical_details.txt
+[afl-fuzz approach]: https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/afl-fuzz_approach.md
+[afl-fuzz README]: https://github.com/AFLplusplus/AFLplusplus/blob/stable/README.md
+[Fuzzing in depth]: https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/fuzzing_in_depth.md
+[Technical whitepaper for AFL++]: https://aflplus.plus/papers/aflpp-woot2020.pdf
 
 As an example, we are going to fuzz [Jil],
 which is a fast JSON serializer and deserializer
@@ -291,7 +291,7 @@ some useful results within minutes, but sometimes
 it can take more than a day, so be patient.
 
 The input files responsible for unhandled exceptions will
-appear in the ```findings/crashes``` directory. The total
+appear in the ```findings/default/crashes``` directory. The total
 number of unique crashes will be displayed in red on the
 afl-fuzz status screen.
 

--- a/docs/miscellaneous.md
+++ b/docs/miscellaneous.md
@@ -16,7 +16,7 @@ terminate and display the following error message:
 
 If you encounter this message during fuzzing, you can recover
 the input data that has caused the premature exit from the file
-```findings_dir/.cur_input```.
+```findings_dir/default/.cur_input```.
 
 There is also an out-of-process version of fuzzer which is
 using two different .NET processes: the master process for
@@ -55,7 +55,3 @@ You can run it using the following command:
 afl-tmin -i test_case -o minimized_result \
   dotnet path_to_assembly
 ```
-
-The only change you have to make in your fuzzing
-project is to replace the **Fuzzer.Run** call with
-the call to **Fuzzer.RunOnce**.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,16 +2,16 @@
 set -eux
 
 # Download and extract the latest afl-fuzz source package
-wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz
-tar -xvf afl-latest.tgz
+wget https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v4.30c.tar.gz
+tar -xvzf v4.30c.tar.gz
 
-rm afl-latest.tgz
-cd afl-2.52b/
+rm v4.30c.tar.gz
+cd AFLplusplus-4.30c/
 
 # Install afl-fuzz
 sudo make install
 cd ..
-rm -rf afl-2.52b/
+rm -rf AFLplusplus-4.30c/
 
 # Install SharpFuzz.CommandLine global .NET tool
 dotnet tool install --global SharpFuzz.CommandLine

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -10,7 +10,7 @@ dotnet publish src/SharpFuzz.CommandLine/SharpFuzz.CommandLine.csproj `
     -i corpus `
     -command out/SharpFuzz.CommandLine
 
-$output = Get-Content -Path "./findings/.cur_input" -Raw
+$output = Get-Content -Path "./findings/default/.cur_input" -Raw
 $crasher = "Whoopsie"
 
 if (-not $output.Contains($crasher)) {


### PR DESCRIPTION
I'm not sure if there was a special reason to remain on AFL instead of AFL++, but the latter should be better in any metric. It therefore would help to have it as a default.

Done:
- updated to AFL++ v4.30c
- updated documentation
- run Github action
- tested Fuzzer.Run, Fuzzer.OutOfProcess.Run and afl-tmin

What exactly was the reason behind Fuzzer.RunOnce only for afl-tmin?
It does not work with AFL++ but I have no problem minimizing my crashes with both Fuzzer.Run and Fuzzer.OutOfProcess.Run.
Could it maybe be removed ? Or are there edge-cases where we need it ?

